### PR TITLE
Add stacks api

### DIFF
--- a/stack_test.go
+++ b/stack_test.go
@@ -179,9 +179,9 @@ func TestUpdateStack(t *testing.T) {
 	server, client := gapiTestTools(t, 200, getStacksJSON)
 	defer server.Close()
 
-	errr := client.UpdateStack(1, "mystack-update", "This is a test stack")
-	if errr != nil {
-		t.Error(errr)
+	err := client.UpdateStack(1, "mystack-update", "This is a test stack")
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -91,7 +91,6 @@ const (
 )
 
 func TestStacks(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, getStacksJSON)
 	defer server.Close()
 
@@ -108,42 +107,39 @@ func TestStacks(t *testing.T) {
 		t.Errorf("Length of returned stacks - Actual Stacks Count: %d, Expected Stacks Count: %d", actualItemCound, expectedItemCount)
 	}
 
-	actualStackId := stacks.Items[0].ID
-	expectedStackId := int64(1)
+	actualStackID := stacks.Items[0].ID
+	expectedStackID := int64(1)
 
-	if actualStackId != expectedStackId {
-		t.Errorf("Unexpected Stack ID - Actual Stack ID: %d, Expected Stack ID: %d", actualStackId, expectedStackId)
+	if actualStackID != expectedStackID {
+		t.Errorf("Unexpected Stack ID - Actual Stack ID: %d, Expected Stack ID: %d", actualStackID, expectedStackID)
 	}
 
 	actualSlug := stacks.Items[0].Slug
 	expectedSlug := "mystack"
 	if actualSlug != expectedSlug {
-		t.Errorf("Unexpected Stack Slug - Actual Slug: %d, Expected Slug: %d", actualStackId, expectedStackId)
+		t.Errorf("Unexpected Stack Slug - Actual Slug: %d, Expected Slug: %d", actualStackID, expectedStackID)
 	}
-
 }
 
 func TestCreateStack(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, createStackJSON)
 	defer server.Close()
 
-	stackId, err := client.NewStack("mystack", "mystack", "eu")
+	stackID, err := client.NewStack("mystack", "mystack", "eu")
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expectedStackId := int64(1)
-	actualStackId := stackId
+	expectedStackID := int64(1)
+	actualStackID := stackID
 
-	if actualStackId != expectedStackId {
-		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackId, expectedStackId)
+	if actualStackID != expectedStackID {
+		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackID, expectedStackID)
 	}
 }
 
 func TestStackBySlug(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, getStackJSON)
 	defer server.Close()
 
@@ -162,26 +158,24 @@ func TestStackBySlug(t *testing.T) {
 }
 
 func TestStackByID(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, getStackJSON)
 	defer server.Close()
 
-	expectedStackId := int64(1)
-	resp, err := client.StackByID(expectedStackId)
+	expectedStackID := int64(1)
+	resp, err := client.StackByID(expectedStackID)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actualStackId := resp.ID
+	actualStackID := resp.ID
 
-	if actualStackId != expectedStackId {
-		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackId, expectedStackId)
+	if actualStackID != expectedStackID {
+		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackID, expectedStackID)
 	}
 }
 
 func TestUpdateStack(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, getStacksJSON)
 	defer server.Close()
 
@@ -192,7 +186,6 @@ func TestUpdateStack(t *testing.T) {
 }
 
 func TestDeleteStack(t *testing.T) {
-
 	server, client := gapiTestTools(t, 200, getStacksJSON)
 	defer server.Close()
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -103,8 +103,10 @@ func TestStacks(t *testing.T) {
 
 	var expectedStacks StackItems
 
-	UnmarshalJSONToStruct(getStacksJSON, &expectedStacks)
-
+	err = UnmarshalJSONToStruct(getStacksJSON, &expectedStacks)
+	if err != nil {
+		t.Fatal(err)
+	}
 	actualItemCount := len(stacks.Items)
 	expectedItemCount := len(expectedStacks.Items)
 
@@ -140,7 +142,10 @@ func TestCreateStack(t *testing.T) {
 	}
 
 	var expectedStack Stack
-	UnmarshalJSONToStruct(createStackJSON, &expectedStack)
+	err = UnmarshalJSONToStruct(createStackJSON, &expectedStack)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if actualStackID != expectedStack.ID {
 		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackID, expectedStack.ID)
@@ -186,7 +191,7 @@ func TestUpdateStack(t *testing.T) {
 	server, client := gapiTestTools(t, 200, getStacksJSON)
 	defer server.Close()
 
-	err := client.UpdateStack(1, "mystack-update", "This is a test stack")
+	err := client.UpdateStack(1, "mystack2", "mystack2", "This is a test stack update")
 	if err != nil {
 		t.Error(err)
 	}

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,205 @@
+package gapi
+
+import (
+	"testing"
+)
+
+const (
+	getStackJSON    = `{"id": 1,"slug": "mystack"}`
+	createStackJSON = `{"id": 1,"slug": "mystack"}`
+	getStacksJSON   = `
+{
+	"items": [
+		{
+			"id": 1,
+			"orgId": 1,
+			"orgSlug": "myorg",
+			"orgName": "MyOrg",
+			"name": "mystack.grafana.net",
+			"url": "https://mystack.grafana.net",
+			"slug": "mystack",
+			"version": "stable",
+			"description": "My amazing stack",
+			"status": "active",
+			"gateway": "istio",
+			"createdAt": "2021-12-22T14:02:46.000Z",
+			"createdBy": "xyz",
+			"updatedAt": null,
+			"updatedBy": "",
+			"trial": 0,
+			"trialExpiresAt": null,
+			"clusterId": 666,
+			"clusterSlug": "prod-eu-west-0",
+			"clusterName": "prod-eu-west-0",
+			"plan": "gcloud",
+			"planName": "Grafana Cloud",
+			"billingStartDate": "2021-12-22T14:02:46.000Z",
+			"billingEndDate": null,
+			"billingActiveUsers": 0,
+			"currentActiveUsers": 1,
+			"currentActiveAdminUsers": 1,
+			"currentActiveEditorUsers": 0,
+			"currentActiveViewerUsers": 0,
+			"dailyUserCnt": 0,
+			"dailyAdminCnt": 0,
+			"dailyEditorCnt": 0,
+			"dailyViewerCnt": 0,
+			"billableUserCnt": 1,
+			"dashboardCnt": 6,
+			"datasourceCnts": {},
+			"userQuota": 10,
+			"dashboardQuota": -1,
+			"alertQuota": -1,
+			"ssl": true,
+			"customAuth": true,
+			"customDomain": true,
+			"support": true,
+			"runningVersion": "8.3.3 (commit: 30bb7a93c, branch: HEAD)",
+			"machineLearning": 0,
+			"hmInstancePromId": 112233,
+			"hmInstancePromUrl": "https://prometheus-prod-01-eu-west-0.grafana.net",
+			"hmInstancePromName": "mystack-prom",
+			"hmInstancePromStatus": "active",
+			"hmInstancePromCurrentUsage": 11111,
+			"hmInstancePromCurrentActiveSeries": 222222,
+			"hmInstanceGraphiteId": 111111,
+			"hmInstanceGraphiteUrl": "https://graphite-prod-01-eu-west-0.grafana.net",
+			"hmInstanceGraphiteName": "mystack-graphite",
+			"hmInstanceGraphiteType": "graphite-v5",
+			"hmInstanceGraphiteStatus": "active",
+			"hmInstanceGraphiteCurrentUsage": 0,
+			"hlInstanceId": 121416,
+			"hlInstanceUrl": "https://logs-prod-eu-west-0.grafana.net",
+			"hlInstanceName": "mystack-logs",
+			"hlInstanceStatus": "active",
+			"hlInstanceCurrentUsage": 0,
+			"amInstanceId": 654321,
+			"amInstanceName": "mystack-alerts",
+			"amInstanceUrl": "https://alertmanager-eu-west-0.grafana.net",
+			"amInstanceStatus": "active",
+			"amInstanceGeneratorUrl": "https://mystack.grafana.net",
+			"htInstanceId": 123456,
+			"htInstanceUrl": "https://tempo-eu-west-0.grafana.net",
+			"htInstanceName": "mystack-traces",
+			"htInstanceStatus": "active",
+			"regionId": 3,
+			"regionSlug": "eu"
+			}
+	]
+}
+`
+)
+
+func TestStacks(t *testing.T) {
+
+	server, client := gapiTestTools(t, 200, getStacksJSON)
+	defer server.Close()
+
+	stacks, err := client.Stacks()
+
+	if err != nil {
+		t.Fatalf("expected error to be nil; got: %s", err.Error())
+	}
+
+	actualItemCound := len(stacks.Items)
+	expectedItemCount := 1
+
+	if actualItemCound != expectedItemCount {
+		t.Errorf("Length of returned stacks - Actual Stacks Count: %d, Expected Stacks Count: %d", actualItemCound, expectedItemCount)
+	}
+
+	actualStackId := stacks.Items[0].ID
+	expectedStackId := int64(1)
+
+	if actualStackId != expectedStackId {
+		t.Errorf("Unexpected Stack ID - Actual Stack ID: %d, Expected Stack ID: %d", actualStackId, expectedStackId)
+	}
+
+	actualSlug := stacks.Items[0].Slug
+	expectedSlug := "mystack"
+	if actualSlug != expectedSlug {
+		t.Errorf("Unexpected Stack Slug - Actual Slug: %d, Expected Slug: %d", actualStackId, expectedStackId)
+	}
+
+}
+
+func TestCreateStack(t *testing.T) {
+
+	server, client := gapiTestTools(t, 200, createStackJSON)
+	defer server.Close()
+
+	stackId, err := client.NewStack("mystack", "mystack", "eu")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStackId := int64(1)
+	actualStackId := stackId
+
+	if actualStackId != expectedStackId {
+		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackId, expectedStackId)
+	}
+}
+
+func TestStackBySlug(t *testing.T) {
+
+	server, client := gapiTestTools(t, 200, getStackJSON)
+	defer server.Close()
+
+	stack := "mystack"
+	resp, err := client.StackBySlug(stack)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedStack := stack
+	actualStack := resp.Slug
+
+	if actualStack != expectedStack {
+		t.Errorf("Unexpected Stack Slug - Actual: %s, Expected: %s", actualStack, expectedStack)
+	}
+}
+
+func TestStackByID(t *testing.T) {
+
+	server, client := gapiTestTools(t, 200, getStackJSON)
+	defer server.Close()
+
+	expectedStackId := int64(1)
+	resp, err := client.StackByID(expectedStackId)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualStackId := resp.ID
+
+	if actualStackId != expectedStackId {
+		t.Errorf("Unexpected Stack ID - Actual: %d, Expected: %d", actualStackId, expectedStackId)
+	}
+}
+
+func TestUpdateStack(t *testing.T) {
+
+	server, client := gapiTestTools(t, 200, getStacksJSON)
+	defer server.Close()
+
+	errr := client.UpdateStack(1, "mystack-update", "This is a test stack")
+	if errr != nil {
+		t.Error(errr)
+	}
+}
+
+func TestDeleteStack(t *testing.T) {
+
+	server, client := gapiTestTools(t, 200, getStacksJSON)
+	defer server.Close()
+
+	err := client.DeleteStack("mystack")
+
+	// The DELETE api returns an error so check if there is an error
+	if err != nil {
+		t.Errorf("Unexpected error - Actual: %s, Expected: nil", err.Error())
+	}
+}

--- a/stacks.go
+++ b/stacks.go
@@ -157,9 +157,10 @@ func (c *Client) NewStack(stackName string, stackSlug string, region string) (in
 
 // UpdateOrg updates a Grafana stack.
 // Only the name can be updated. No other parameters of the stack are updatable
-func (c *Client) UpdateStack(id int64, name string, description string) error {
+func (c *Client) UpdateStack(id int64, name string, slug string, description string) error {
 	dataMap := map[string]string{
 		"name":        name,
+		"slug":        slug,
 		"description": description,
 	}
 	data, err := json.Marshal(dataMap)

--- a/stacks.go
+++ b/stacks.go
@@ -7,42 +7,43 @@ import (
 	"time"
 )
 
+// https://grafana.com/docs/grafana-cloud/reference/cloud-api/#stacks
 type Stack struct {
-	ID                       int64       `json:"id"`
-	OrgID                    int64       `json:"orgId"`
-	OrgSlug                  string      `json:"orgSlug"`
-	OrgName                  string      `json:"orgName"`
-	Name                     string      `json:"name"`
-	URL                      string      `json:"url"`
-	Slug                     string      `json:"slug"`
-	Version                  string      `json:"version"`
-	Description              string      `json:"description"`
-	Status                   string      `json:"status"`
-	Gateway                  string      `json:"gateway"`
-	CreatedAt                time.Time   `json:"createdAt"`
-	CreatedBy                string      `json:"createdBy"`
+	ID                       int64     `json:"id"`
+	OrgID                    int64     `json:"orgId"`
+	OrgSlug                  string    `json:"orgSlug"`
+	OrgName                  string    `json:"orgName"`
+	Name                     string    `json:"name"`
+	URL                      string    `json:"url"`
+	Slug                     string    `json:"slug"`
+	Version                  string    `json:"version"`
+	Description              string    `json:"description"`
+	Status                   string    `json:"status"`
+	Gateway                  string    `json:"gateway"`
+	CreatedAt                time.Time `json:"createdAt"`
+	CreatedBy                string    `json:"createdBy"`
 	UpdatedAt                time.Time `json:"updatedAt"`
-	UpdatedBy                string      `json:"updatedBy"`
-	Trial                    int         `json:"trial"`
+	UpdatedBy                string    `json:"updatedBy"`
+	Trial                    int       `json:"trial"`
 	TrialExpiresAt           time.Time `json:"trialExpiresAt"`
-	ClusterID                int         `json:"clusterId"`
-	ClusterSlug              string      `json:"clusterSlug"`
-	ClusterName              string      `json:"clusterName"`
-	Plan                     string      `json:"plan"`
-	PlanName                 string      `json:"planName"`
-	BillingStartDate         time.Time   `json:"billingStartDate"`
+	ClusterID                int       `json:"clusterId"`
+	ClusterSlug              string    `json:"clusterSlug"`
+	ClusterName              string    `json:"clusterName"`
+	Plan                     string    `json:"plan"`
+	PlanName                 string    `json:"planName"`
+	BillingStartDate         time.Time `json:"billingStartDate"`
 	BillingEndDate           time.Time `json:"billingEndDate"`
-	BillingActiveUsers       int         `json:"billingActiveUsers"`
-	CurrentActiveUsers       int         `json:"currentActiveUsers"`
-	CurrentActiveAdminUsers  int         `json:"currentActiveAdminUsers"`
-	CurrentActiveEditorUsers int         `json:"currentActiveEditorUsers"`
-	CurrentActiveViewerUsers int         `json:"currentActiveViewerUsers"`
-	DailyUserCnt             int         `json:"dailyUserCnt"`
-	DailyAdminCnt            int         `json:"dailyAdminCnt"`
-	DailyEditorCnt           int         `json:"dailyEditorCnt"`
-	DailyViewerCnt           int         `json:"dailyViewerCnt"`
-	BillableUserCnt          int         `json:"billableUserCnt"`
-	DashboardCnt             int         `json:"dashboardCnt"`
+	BillingActiveUsers       int       `json:"billingActiveUsers"`
+	CurrentActiveUsers       int       `json:"currentActiveUsers"`
+	CurrentActiveAdminUsers  int       `json:"currentActiveAdminUsers"`
+	CurrentActiveEditorUsers int       `json:"currentActiveEditorUsers"`
+	CurrentActiveViewerUsers int       `json:"currentActiveViewerUsers"`
+	DailyUserCnt             int       `json:"dailyUserCnt"`
+	DailyAdminCnt            int       `json:"dailyAdminCnt"`
+	DailyEditorCnt           int       `json:"dailyEditorCnt"`
+	DailyViewerCnt           int       `json:"dailyViewerCnt"`
+	BillableUserCnt          int       `json:"billableUserCnt"`
+	DashboardCnt             int       `json:"dashboardCnt"`
 	DatasourceCnts           struct {
 	} `json:"datasourceCnts"`
 	UserQuota                         int    `json:"userQuota"`
@@ -126,31 +127,11 @@ func (c *Client) StackByID(id int64) (Stack, error) {
 		return stack, err
 	}
 
-	// If we are getting a deleted stack then return an empty stack
-	if stack.Status == "deleted" {
-		return Stack{}, err
-	}
-
 	return stack, err
 }
 
 // NewStack creates a new Grafana Stack
 func (c *Client) NewStack(stackName string, stackSlug string, region string) (int64, error) {
-	id := int64(0)
-
-	// Check if this stack already exists
-	stack, stackErr := c.StackBySlug(stackSlug)
-
-	if stackErr != nil {
-		return id, nil
-	}
-
-	// If the stack already exist then return the existing ID
-	// There is currently no API for updating a stack so if one exists already we just return its ID
-	if stack.ID != 0 {
-		return stack.ID, nil
-	}
-
 	dataMap := map[string]string{
 		"name":   stackName,
 		"slug":   stackSlug,
@@ -159,7 +140,7 @@ func (c *Client) NewStack(stackName string, stackSlug string, region string) (in
 
 	data, err := json.Marshal(dataMap)
 	if err != nil {
-		return id, err
+		return 0, err
 	}
 
 	result := struct {
@@ -171,7 +152,7 @@ func (c *Client) NewStack(stackName string, stackSlug string, region string) (in
 		return 0, err
 	}
 
-	return result.ID, err
+	return result.ID, nil
 }
 
 // UpdateOrg updates a Grafana stack.

--- a/stacks.go
+++ b/stacks.go
@@ -106,7 +106,6 @@ func (c *Client) Stacks() (StackItems, error) {
 
 // StackByName fetches and returns the stack whose slug it's passed.
 func (c *Client) StackBySlug(slug string) (Stack, error) {
-
 	stack := Stack{}
 	err := c.request("GET", fmt.Sprintf("/api/instances/%s", slug), nil, nil, &stack)
 
@@ -120,7 +119,6 @@ func (c *Client) StackBySlug(slug string) (Stack, error) {
 // StackByID fetches and returns the stack whose name it's passed.
 // This returns deleted instances as well with `status=deleted`.
 func (c *Client) StackByID(id int64) (Stack, error) {
-
 	stack := Stack{}
 	err := c.request("GET", fmt.Sprintf("/api/instances/%d", id), nil, nil, &stack)
 

--- a/stacks.go
+++ b/stacks.go
@@ -21,17 +21,17 @@ type Stack struct {
 	Gateway                  string      `json:"gateway"`
 	CreatedAt                time.Time   `json:"createdAt"`
 	CreatedBy                string      `json:"createdBy"`
-	UpdatedAt                interface{} `json:"updatedAt"`
+	UpdatedAt                time.Time `json:"updatedAt"`
 	UpdatedBy                string      `json:"updatedBy"`
 	Trial                    int         `json:"trial"`
-	TrialExpiresAt           interface{} `json:"trialExpiresAt"`
+	TrialExpiresAt           time.Time `json:"trialExpiresAt"`
 	ClusterID                int         `json:"clusterId"`
 	ClusterSlug              string      `json:"clusterSlug"`
 	ClusterName              string      `json:"clusterName"`
 	Plan                     string      `json:"plan"`
 	PlanName                 string      `json:"planName"`
 	BillingStartDate         time.Time   `json:"billingStartDate"`
-	BillingEndDate           interface{} `json:"billingEndDate"`
+	BillingEndDate           time.Time `json:"billingEndDate"`
 	BillingActiveUsers       int         `json:"billingActiveUsers"`
 	CurrentActiveUsers       int         `json:"currentActiveUsers"`
 	CurrentActiveAdminUsers  int         `json:"currentActiveAdminUsers"`

--- a/stacks.go
+++ b/stacks.go
@@ -1,0 +1,197 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type Stack struct {
+	ID                       int64       `json:"id"`
+	OrgID                    int64       `json:"orgId"`
+	OrgSlug                  string      `json:"orgSlug"`
+	OrgName                  string      `json:"orgName"`
+	Name                     string      `json:"name"`
+	URL                      string      `json:"url"`
+	Slug                     string      `json:"slug"`
+	Version                  string      `json:"version"`
+	Description              string      `json:"description"`
+	Status                   string      `json:"status"`
+	Gateway                  string      `json:"gateway"`
+	CreatedAt                time.Time   `json:"createdAt"`
+	CreatedBy                string      `json:"createdBy"`
+	UpdatedAt                interface{} `json:"updatedAt"`
+	UpdatedBy                string      `json:"updatedBy"`
+	Trial                    int         `json:"trial"`
+	TrialExpiresAt           interface{} `json:"trialExpiresAt"`
+	ClusterID                int         `json:"clusterId"`
+	ClusterSlug              string      `json:"clusterSlug"`
+	ClusterName              string      `json:"clusterName"`
+	Plan                     string      `json:"plan"`
+	PlanName                 string      `json:"planName"`
+	BillingStartDate         time.Time   `json:"billingStartDate"`
+	BillingEndDate           interface{} `json:"billingEndDate"`
+	BillingActiveUsers       int         `json:"billingActiveUsers"`
+	CurrentActiveUsers       int         `json:"currentActiveUsers"`
+	CurrentActiveAdminUsers  int         `json:"currentActiveAdminUsers"`
+	CurrentActiveEditorUsers int         `json:"currentActiveEditorUsers"`
+	CurrentActiveViewerUsers int         `json:"currentActiveViewerUsers"`
+	DailyUserCnt             int         `json:"dailyUserCnt"`
+	DailyAdminCnt            int         `json:"dailyAdminCnt"`
+	DailyEditorCnt           int         `json:"dailyEditorCnt"`
+	DailyViewerCnt           int         `json:"dailyViewerCnt"`
+	BillableUserCnt          int         `json:"billableUserCnt"`
+	DashboardCnt             int         `json:"dashboardCnt"`
+	DatasourceCnts           struct {
+	} `json:"datasourceCnts"`
+	UserQuota                         int    `json:"userQuota"`
+	DashboardQuota                    int    `json:"dashboardQuota"`
+	AlertQuota                        int    `json:"alertQuota"`
+	Ssl                               bool   `json:"ssl"`
+	CustomAuth                        bool   `json:"customAuth"`
+	CustomDomain                      bool   `json:"customDomain"`
+	Support                           bool   `json:"support"`
+	RunningVersion                    string `json:"runningVersion"`
+	MachineLearning                   int    `json:"machineLearning"`
+	HmInstancePromID                  int    `json:"hmInstancePromId"`
+	HmInstancePromURL                 string `json:"hmInstancePromUrl"`
+	HmInstancePromName                string `json:"hmInstancePromName"`
+	HmInstancePromStatus              string `json:"hmInstancePromStatus"`
+	HmInstancePromCurrentUsage        int    `json:"hmInstancePromCurrentUsage"`
+	HmInstancePromCurrentActiveSeries int    `json:"hmInstancePromCurrentActiveSeries"`
+	HmInstanceGraphiteID              int    `json:"hmInstanceGraphiteId"`
+	HmInstanceGraphiteURL             string `json:"hmInstanceGraphiteUrl"`
+	HmInstanceGraphiteName            string `json:"hmInstanceGraphiteName"`
+	HmInstanceGraphiteType            string `json:"hmInstanceGraphiteType"`
+	HmInstanceGraphiteStatus          string `json:"hmInstanceGraphiteStatus"`
+	HmInstanceGraphiteCurrentUsage    int    `json:"hmInstanceGraphiteCurrentUsage"`
+	HlInstanceID                      int    `json:"hlInstanceId"`
+	HlInstanceURL                     string `json:"hlInstanceUrl"`
+	HlInstanceName                    string `json:"hlInstanceName"`
+	HlInstanceStatus                  string `json:"hlInstanceStatus"`
+	HlInstanceCurrentUsage            int    `json:"hlInstanceCurrentUsage"`
+	AmInstanceID                      int    `json:"amInstanceId"`
+	AmInstanceName                    string `json:"amInstanceName"`
+	AmInstanceURL                     string `json:"amInstanceUrl"`
+	AmInstanceStatus                  string `json:"amInstanceStatus"`
+	AmInstanceGeneratorURL            string `json:"amInstanceGeneratorUrl"`
+	HtInstanceID                      int    `json:"htInstanceId"`
+	HtInstanceURL                     string `json:"htInstanceUrl"`
+	HtInstanceName                    string `json:"htInstanceName"`
+	HtInstanceStatus                  string `json:"htInstanceStatus"`
+	RegionID                          int    `json:"regionId"`
+	RegionSlug                        string `json:"regionSlug"`
+	Links                             []struct {
+		Rel  string `json:"rel"`
+		Href string `json:"href"`
+	} `json:"links"`
+}
+
+// StackItems represents Grafana stack items.
+type StackItems struct {
+	Items []*Stack `json:"items"`
+}
+
+// Stacks fetches and returns the Grafana stacks.
+func (c *Client) Stacks() (StackItems, error) {
+	stacks := StackItems{}
+	err := c.request("GET", "/api/instances", nil, nil, &stacks)
+	if err != nil {
+		return stacks, err
+	}
+
+	return stacks, err
+}
+
+// StackByName fetches and returns the stack whose slug it's passed.
+func (c *Client) StackBySlug(slug string) (Stack, error) {
+
+	stack := Stack{}
+	err := c.request("GET", fmt.Sprintf("/api/instances/%s", slug), nil, nil, &stack)
+
+	if err != nil {
+		return stack, err
+	}
+
+	return stack, err
+}
+
+// StackByID fetches and returns the stack whose name it's passed.
+// This returns deleted instances as well with `status=deleted`.
+func (c *Client) StackByID(id int64) (Stack, error) {
+
+	stack := Stack{}
+	err := c.request("GET", fmt.Sprintf("/api/instances/%d", id), nil, nil, &stack)
+
+	if err != nil {
+		return stack, err
+	}
+
+	// If we are getting a deleted stack then return an empty stack
+	if stack.Status == "deleted" {
+		return Stack{}, err
+	}
+
+	return stack, err
+}
+
+// NewStack creates a new Grafana Stack
+func (c *Client) NewStack(stackName string, stackSlug string, region string) (int64, error) {
+	id := int64(0)
+
+	// Check if this stack already exists
+	stack, stackErr := c.StackBySlug(stackSlug)
+
+	if stackErr != nil {
+		return id, nil
+	}
+
+	// If the stack already exist then return the existing ID
+	// There is currently no API for updating a stack so if one exists already we just return its ID
+	if stack.ID != 0 {
+		return stack.ID, nil
+	}
+
+	dataMap := map[string]string{
+		"name":   stackName,
+		"slug":   stackSlug,
+		"region": region,
+	}
+
+	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return id, err
+	}
+
+	result := struct {
+		ID int64 `json:"id"`
+	}{}
+
+	err = c.request("POST", "/api/instances", nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return 0, err
+	}
+
+	return result.ID, err
+}
+
+// UpdateOrg updates a Grafana stack.
+// Only the name can be updated. No other parameters of the stack are updatable
+func (c *Client) UpdateStack(id int64, name string, description string) error {
+	dataMap := map[string]string{
+		"name":        name,
+		"description": description,
+	}
+	data, err := json.Marshal(dataMap)
+	if err != nil {
+		return err
+	}
+
+	return c.request("POST", fmt.Sprintf("/api/instances/%d", id), nil, bytes.NewBuffer(data), nil)
+}
+
+// DeleteStack deletes the Grafana stack whose slug it passed in.
+func (c *Client) DeleteStack(stackSlug string) error {
+	return c.request("DELETE", fmt.Sprintf("/api/instances/%s", stackSlug), nil, nil, nil)
+}


### PR DESCRIPTION
ℹ️  **This enhancement will enable [terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana) to provision [Grafana stacks](https://grafana.com/docs/grafana-cloud/reference/cloud-api/#stacks).**

This PR:
Adds a new [Grafana Cloud Stacks API](https://grafana.com/docs/grafana-cloud/reference/cloud-api/#stacks).
This can be used to:
* Get a list of stacks
* Updates an existing stack
  * Updates are limited, you can only update name and description.
* Get Stack by ID
* Get Stack by slug
* Delete a stack by slug
